### PR TITLE
Bring Develop to Master for Staging

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2016-11-13  Russell S. Pierce  <russell.s.pierce@gmail.com>
+* Updated naptime:::nap_warn() to incorporate a (suggestion)[https://github.com/drknexus/naptime/issues/5] by Hadley Wickham
+* Formatting tweaks and rebuild for vignette
+
 2016-11-12  Russell S. Pierce  <russell.s.pierce@gmail.com>
 * Fail as expected for non-standard character input when character count is below 8.  This change restores code coverage to 100%
 * Corrected issues in the github description and/or vignette and standardized the location so there is only one version of the expository text.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 2016-11-13  Russell S. Pierce  <russell.s.pierce@gmail.com>
-* Updated naptime:::nap_warn() to incorporate a (suggestion)[https://github.com/drknexus/naptime/issues/5] by Hadley Wickham
+* Overhauled naptime:::nap_warn() to incorporate a (suggestion)[https://github.com/drknexus/naptime/issues/5] by Hadley Wickham
 * Formatting tweaks and rebuild for vignette
+* Fixed bug for difftime where there was an assumption that the units were in seconds
 
 2016-11-12  Russell S. Pierce  <russell.s.pierce@gmail.com>
 * Fail as expected for non-standard character input when character count is below 8.  This change restores code coverage to 100%

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: naptime
 Type: Package
-Title: A Robust Flexible Sys.sleep() Replacement
-Version: 1.1.0
+Title: A Flexible and Robust Sys.sleep() Replacement
+Version: 1.1.1
 Date: 2016-11-12
 Authors@R: c(
   person("Russell", "Pierce", role = c("aut", "cre"), email = "russell.s.pierce@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # naptime 1.1.0
 
+## Behavior changes
+
+* Per [request](https://github.com/drknexus/naptime/issues/6) naptime is now quite a bit more discerning by default.  If the argument provided isn't interpretable, it will thrown an error.  The old permissive behavior that produces warnings and default delays can be more or less restored by setting the option `naptime.permissive` to TRUE.
+* Logicals no longer produce a warning.  Logical FALSE is interpreted as meaning 'no delay' and TRUE is interpreted as meaning default delay.
+* Calling naptime with a NULL no longer produces a delay or warning as this is interpreted as meaning 'no delay'.
+
 ## New Features
 
 * naptime can take incompletely specified date times for delays in the future by leveraging lubridate::ymd_hms()'s truncated parameter.  We now allow for three truncated formats.
@@ -8,6 +14,7 @@
 
 * naptime actually pauses for the default duration under error conditions rather than returning it as a variable
 * naptime no longer sometimes returns non-NULL values
+* naptime should now delay appropriately for long duration difftimes
 
 # naptime 1.0.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Behavior changes
 
-* Per [request](https://github.com/drknexus/naptime/issues/6) naptime is now quite a bit more discerning by default.  If the argument provided isn't interpretable, it will thrown an error.  The old permissive behavior that produces warnings and default delays can be more or less restored by setting the option `naptime.permissive` to TRUE.
+* Per [request](https://github.com/drknexus/naptime/issues/6) naptime is now quite a bit more discerning by default.  If the argument provided isn't interpretable, it will thrown as an error.  The old permissive behavior that produces warnings and default delays can be more or less restored by setting the option `naptime.permissive` to TRUE or setting the permissive parameter as TRUE on any given naptime call (parameter overrides the option)
 * Logicals no longer produce a warning.  Logical FALSE is interpreted as meaning 'no delay' and TRUE is interpreted as meaning default delay.
 * Calling naptime with a NULL no longer produces a delay or warning as this is interpreted as meaning 'no delay'.
 

--- a/R/naptime-internal.R
+++ b/R/naptime-internal.R
@@ -1,6 +1,6 @@
 nap_default <- function() naptime(getOption("naptime.default_delay", 0.1))
 nap_warn <- function(...) {
   if (getOption("naptime.warnings", TRUE)) {
-    warning(...)
+    warning(..., call. = FALSE)
   }
 }

--- a/R/naptime-internal.R
+++ b/R/naptime-internal.R
@@ -1,11 +1,12 @@
+permissive_default <- FALSE
 nap_default <- function() naptime(getOption("naptime.default_delay", 0.1))
 nap_warn <- function(...) {
   if (getOption("naptime.warnings", TRUE)) {
     warning(..., call. = FALSE)
   }
 }
-nap_error <- function(...) {
- if (getOption("naptime.permissive", FALSE)) {
+nap_error <- function(..., permissive = getOption("naptime.permissive", permissive_default)) {
+ if (permissive) {
    nap_warn(...)
  } else {
    stop(..., call. = FALSE)

--- a/R/naptime-internal.R
+++ b/R/naptime-internal.R
@@ -4,3 +4,10 @@ nap_warn <- function(...) {
     warning(..., call. = FALSE)
   }
 }
+nap_error <- function(...) {
+ if (getOption("naptime.permissive", FALSE)) {
+   nap_warn(...)
+ } else {
+   stop(..., call. = FALSE)
+ }
+}

--- a/R/naptime.R
+++ b/R/naptime.R
@@ -107,7 +107,7 @@ setMethod("naptime", signature("logical"),
               if (isTRUE(!time)) {
                 NULL
               } else {
-                nap_error("Logical provided to naptime() is not TRUE or FALSE.")
+                nap_error("Logical provided to naptime() is not TRUE or FALSE.", permissive = permissive)
                 nap_default()
               }
             }
@@ -133,7 +133,7 @@ setMethod("naptime", signature("character"),
               time_parsed <- try(lubridate::ymd_hms(time, tz = time_zone, truncated = 3), silent = TRUE)
             }
             if ("try-error" %in% class(time_parsed) || is.na(time_parsed)) {
-              nap_error("Could not parse '", time, "' as time")
+              nap_error("Could not parse '", time, "' as time", permissive = permissive)
               nap_default()
             } else {
               t <- time_parsed - lubridate::now(tzone = lubridate::tz(time_parsed))

--- a/R/naptime.R
+++ b/R/naptime.R
@@ -4,14 +4,19 @@
 #' \itemize{
 #'  \item numeric: time in seconds to nap
 #'  \item POSIXct: time at which the nap should stop  (timezone is respected)
-#'  \item Period: time from now at which the nap should stop
 #'  \item character: yyyy-mm-dd hh:mm:ss at which nap should stop, time zone is assumed to be Sys.timezone() and hh:mm:ss is optional as three formats may be missing, cf. lubridate::ymd_hms().
+#'  \item Period: time from now at which the nap should stop
 #'  \item difftime: difference in time to nap
-#'  \item logical: nap for default duration
-#'  \item NULL: nap for default duration
-#'  \item generic: nap for default duration
+#'  \item logical: If TRUE, nap for default duration, otherwise don't nap.
+#'  \item NULL: don't nap
+#'  \item generic: error or nap for default duration depending on the option naptime.permissive
 #' }
+#'
+#' The default duration is set with a numeric for the option \code{naptime.default_delay} in seconds (default: 0.1)
+#' Whether a generic input is accepted is determined by the option \code{naptime.permissive} (default: FALSE)
+#'
 #' @param time Time to sleep, polymorphic type inputs, leaning towards units as 'seconds'
+#' @param permissive An optional argument to override the \code{naptime.permissive option} for this call of the naptime function
 #' @rdname naptime
 #'
 #' @return NULL; A side effect of a pause in program execution
@@ -25,97 +30,113 @@
 #' }
 
 setGeneric("naptime",
-           function(time)
+           function(time, permissive = getOption("naptime.permissive", permissive_default))
            {
              if (missing(time)) {
-               time <- getOption("naptime.default_delay", 0.1)
+               nap_default()
+             } else if (!is.null(time) && length(time) != 1L) {
+               nap_error("The time paramater was not scalar (length equal to 1)", permissive = permissive)
+               if (length(time) > 0) {
+                 naptime(time[1], permissive = permissive)
+               } else {
+                 naptime(permissive = permissive)
+               }
+             } else {
+               tryCatch(
+                 standardGeneric("naptime")
+                 , error = function(e) {
+                   nap_error("unhandled input for naptime(): ", as.character(e), permissive = permissive)
+                   nap_default()
+                 }
+               )
              }
-             tryCatch(
-              standardGeneric("naptime")
-              , error = function(e) {
-                nap_warn("unhandled input for naptime: ", as.character(e), "; sleeping for default duration")
-                nap_default()
-              }
-             )
              return(NULL)
            })
 
 #' @rdname naptime
 setMethod("naptime", signature("numeric"),
-          function(time)
+          function(time, permissive = getOption("naptime.permissive", permissive_default))
           {
-            if (is.finite(time) && time >= 0)
+            if (is.finite(time) && time >= 0) {
               Sys.sleep(time)
-            else {
-              nap_warn('Non-finite or negative time passed to naptime(), sleeping for default duration')
+            } else if (!is.finite(time) && time > 0) {
+              nap_error("naptime() provided with a time that was positive and non-finite", permissive = permissive)
               nap_default()
+            } else {
+              nap_warn("naptime() provided with a time that was negative or in the past, skipping delay")
             }
           })
 
 #' @rdname naptime
 setMethod("naptime", signature("Period"),
-          function(time)
+          function(time, permissive = getOption("naptime.permissive", permissive_default))
           {
-            t <- lubridate::period_to_seconds(time)
-            if (t < 0) {
-              nap_warn('Time interval is less than zero, sleeping for .Options$naptime.default_delay seconds.')
-              t <- getOption("naptime.default_delay")
-            }
-            Sys.sleep(t)
+            naptime(lubridate::period_to_seconds(time), permissive = permissive)
           })
 
 #' @rdname naptime
 setMethod("naptime", signature("POSIXct"),
-          function(time)
+          function(time, permissive = getOption("naptime.permissive", permissive_default))
           {
             t <- as.numeric(time) - as.numeric(lubridate::now(tzone = lubridate::tz(time)))
-            naptime(t)
+            naptime(t, permissive = permissive)
           })
 
 #' @rdname naptime
 setMethod("naptime", signature("difftime"),
-          function(time)
+          function(time, permissive = getOption("naptime.permissive", permissive_default))
           {
-            t <- as.numeric(time)
-            if (t < 0) {
-              nap_warn('Time interval is less than zero.')
-              t <- 0
-            }
-            Sys.sleep(t)
+            #Use the units of difftime to construct a Period
+            secs <- lubridate::seconds
+            naptime(
+              eval(
+                parse(
+                  text=paste0(attr(time, "units"), "(", as.numeric(time), ")")
+                  )
+                )
+            , permissive = permissive)
           })
 
 #' @rdname naptime
 setMethod("naptime", signature("logical"),
-          function(time)
+          function(time, permissive = getOption("naptime.permissive", permissive_default))
           {
-            nap_warn('Logical passed to naptime(), sleeping for default duration')
-            nap_default()
+            if (isTRUE(time)) {
+              nap_default()
+            } else {
+              if (isTRUE(!time)) {
+                NULL
+              } else {
+                nap_error("Logical provided to naptime() is not TRUE or FALSE.")
+                nap_default()
+              }
+            }
           })
 
 #' @rdname naptime
 setMethod("naptime", signature("NULL"),
-          function(time)
+          function(time, permissive = getOption("naptime.permissive", permissive_default))
           {
-            nap_warn('NULL passed to naptime(), sleeping for default duration')
-            nap_default()
+            NULL
           })
 
 #' @rdname naptime
 setMethod("naptime", signature("character"),
-          function(time)
+          function(time, permissive = getOption("naptime.permissive", permissive_default))
           {
             time_zone <- ifelse(is.na(Sys.timezone()), "UTC", Sys.timezone())
-            if (nchar(time) >= 8) {
-              time_parsed <- try(lubridate::ymd_hms(time, tz = time_zone, truncated = 3), silent = TRUE)
-            } else {
+            num_char <- nchar(time)
+            if (is.na(num_char) || num_char < 8) {
               # Times that aren't at least 8 characters long do not have a reasonable chance of being parsable
               time_parsed <- NA
+            } else if (num_char >= 8) {
+              time_parsed <- try(lubridate::ymd_hms(time, tz = time_zone, truncated = 3), silent = TRUE)
             }
             if ("try-error" %in% class(time_parsed) || is.na(time_parsed)) {
-              nap_warn("Could not parse ", time, " as time, sleeping for default duration.")
+              nap_error("Could not parse '", time, "' as time")
               nap_default()
             } else {
               t <- time_parsed - lubridate::now(tzone = lubridate::tz(time_parsed))
-              naptime(t)
+              naptime(t, permissive = permissive)
             }
           })

--- a/R/naptime.R
+++ b/R/naptime.R
@@ -3,12 +3,12 @@
 #' Acceptable inputs:
 #' \itemize{
 #'  \item numeric: time in seconds to nap
-#'  \item NULL: nap for default duration
 #'  \item POSIXct: time at which the nap should stop  (timezone is respected)
 #'  \item Period: time from now at which the nap should stop
 #'  \item character: yyyy-mm-dd hh:mm:ss at which nap should stop, time zone is assumed to be Sys.timezone() and hh:mm:ss is optional as three formats may be missing, cf. lubridate::ymd_hms().
 #'  \item difftime: difference in time to nap
 #'  \item logical: nap for default duration
+#'  \item NULL: nap for default duration
 #'  \item generic: nap for default duration
 #' }
 #' @param time Time to sleep, polymorphic type inputs, leaning towards units as 'seconds'

--- a/README.md
+++ b/README.md
@@ -26,53 +26,57 @@ All options are set via `base::options()`.
 
 naptime() accepts a wide variety of inputs.
 
-Polymorphism for: \* numeric: time in seconds to nap
+Polymorphism for:
+
+-   numeric: time in seconds to nap
 
 ``` r
 naptime(1)
+#> NULL
 ```
 
 -   NULL
 
 ``` r
 naptime(NULL)
-#> Warning in nap_warn("NULL passed to naptime(), sleeping for .Options
-#> $naptime.default_delay seconds."): NULL passed to naptime(), sleeping
-#> for .Options$naptime.default_delay seconds.
-#> [1] 0.1
+#> Warning: NULL passed to naptime(), sleeping for default duration
+#> NULL
 ```
 
 -   POSIXct: time at which the nap should stop (timezone is respected)
 
 ``` r
 naptime(lubridate::now(tzone = "UTC")+lubridate::seconds(1))
+#> NULL
 ```
 
 -   Period: time from now at which the nap should stop
 
 ``` r
 naptime(lubridate::seconds(1))
+#> NULL
 ```
 
--   character: ymd\_hms at which nap should stop, time zone is assumed to be device local
+-   character: ymd\_hms at which nap should stop, time zone is assumed to be device local. The hour, minute, and second do not need to be specified.
 
 ``` r
 naptime(as.character(lubridate::now() + lubridate::seconds(1)))
+#> NULL
 ```
 
 -   difftime: difference in time to nap
 
 ``` r
 naptime(difftime(lubridate::now() + seconds(1), lubridate::now()))
+#> NULL
 ```
 
 -   logical: nap for default duration
 
 ``` r
 naptime(TRUE)
-#> Warning in nap_warn("Logical passed to naptime(), sleeping for 0
-#> seconds."): Logical passed to naptime(), sleeping for 0 seconds.
-#> [1] 0.1
+#> Warning: Logical passed to naptime(), sleeping for default duration
+#> NULL
 ```
 
 -   generic: nap for default duration
@@ -83,9 +87,9 @@ naptime(glm(rnorm(5) ~ rnorm(5)))
 #> on the right-hand side and was dropped
 #> Warning in model.matrix.default(mt, mf, contrasts): problem with term 1 in
 #> model.matrix: no columns are assigned
-#> Warning in nap_warn("unhandled input for naptime: ", as.character(e), "; sleeping for default duration"): unhandled input for naptime: Error in (function (classes, fdef, mtable) : unable to find an inherited method for function 'naptime' for signature '"glm"'
+#> Warning: unhandled input for naptime: Error in (function (classes, fdef, mtable) : unable to find an inherited method for function 'naptime' for signature '"glm"'
 #> ; sleeping for default duration
-#> [1] 0.1
+#> NULL
 ```
 
 If you find a reasonable input-type for which `naptime::naptime()` doesn't have a reasonable response, please file [an issue](https://github.com/drknexus/naptime/issues).

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ Consider the case of wanting to start processing every hour for a job of an inde
 How do I use it?
 ----------------
 
-Because `naptime()` has nearly identicial arguments and behavior as `base::Sys.sleep()` in response to numeric inputs, it can be nearly used as a drop-in replacement for `base::Sys.sleep()`.
+Because `naptime()` has nearly identical arguments and behavior as `base::Sys.sleep()` in response to numeric inputs, it can be nearly used as a drop-in replacement for `base::Sys.sleep()`.
 
 There are two notable differences in the behavior of Sys.sleep() and naptime():
 
--   For the input value of `Inf` `base::Sys.sleep()` will sleep indefiniately. In contrast, `naptime::naptime()` will produce an error (or if `naptime.permissive = TRUE` is set pause the default duration).
+-   For the input value of `Inf` `base::Sys.sleep()` will sleep indefinitely. In contrast, `naptime::naptime()` will produce an error (or if `naptime.permissive = TRUE` is set pause the default duration).
 -   For a negative input value `base::Sys.sleep()` will produce an error. In contrast, `naptime::naptime()` will assume that the period of delay has already elapsed and move forward without further delay.
 
 ### Options

--- a/README.md
+++ b/README.md
@@ -3,17 +3,44 @@
 Why should I use it?
 --------------------
 
-The premise of naptime is two fold.
+naptime makes delaying code execution in R more flexible and robust. It makes delaying code execution more flexible by supporting more data types than `base::Sys.sleep()`. It makes delaying code more robust by allowing errors in the delay specification to throw warnings instead of errors. Most notably, because naptime supports more input data types, you can use package:lubridate functions in conjunction with naptime to yield human readable time delays and intervals.
 
-1.  Delays in R code should never result in an error.
-2.  Functions should accept multiple inputs types, but result in a single output type or side-effect.
+Consider the case of waiting one hour:
 
-In response to these considerations `naptime::naptime()` either sleeps for the specified duration, or passes forward with a warning. It has the same argument name as `base::Sys.sleep()` and a nearly identical behavior in response to numeric inputs. As such, it can be nearly used as a drop-in replacement for `base::Sys.sleep()`.
+    Sys.sleep(3600)
 
-The one notable exception to identical behavior is the input value of `Inf`. `base::Sys.sleep()` will sleep indefiniately in reponse to `Inf`. In contrast, `naptime::naptime()` will sleep the default duration.
+    # versus
+
+    naptime(lubridate::hours(1))
+
+Consider the case of wanting to start processing every hour for a job of an indeterminate duration:
+
+    repeat{
+      start_time <- lubridate::now()
+      # Do processing
+      sleep_duration <- 3600 - as.numeric(lubridate::now() - start_time)
+      if (sleep_duration > 0) {
+        Sys.sleep(sleep_duration)
+      }
+    }
+
+    # versus
+
+    repeat{
+      start_time <- lubridate::now()
+      # Do processing
+      naptime(start_time + hours(1))
+    }
 
 How do I use it?
 ----------------
+
+Because `naptime()` has nearly identicial arguments and behavior as `base::Sys.sleep()` in response to numeric inputs, it can be nearly used as a drop-in replacement for `base::Sys.sleep()`.
+
+There are two notable differences in the behavior of Sys.sleep() and naptime():
+
+-   For the input value of `Inf` `base::Sys.sleep()` will sleep indefiniately. In contrast, `naptime::naptime()` will produce an error (or if `naptime.permissive = TRUE` is set pause the default duration).
+-   For a negative input value `base::Sys.sleep()` will produce an error. In contrast, `naptime::naptime()` will assume that the period of delay has already elapsed and move forward without further delay.
 
 ### Options
 
@@ -21,6 +48,7 @@ All options are set via `base::options()`.
 
 -   `naptime.default_delay`. If left unchanged, the default delay is `.1` seconds.
 -   `naptime.warnings`. If left unchanged, the default is `TRUE`, to show warnings.
+-   `naptime.permissive`. If left unchanged, the default is `FALSE`, to trigger errors on inputs that couldn't be converted into something sensible. If set TRUE, inputs that couldn't be converted into something sensible will result in a default delay.
 
 ### Polymorphic inputs
 
@@ -32,14 +60,6 @@ Polymorphism for:
 
 ``` r
 naptime(1)
-#> NULL
-```
-
--   NULL
-
-``` r
-naptime(NULL)
-#> Warning: NULL passed to naptime(), sleeping for default duration
 #> NULL
 ```
 
@@ -57,7 +77,7 @@ naptime(lubridate::seconds(1))
 #> NULL
 ```
 
--   character: ymd\_hms at which nap should stop, time zone is assumed to be device local. The hour, minute, and second do not need to be specified.
+-   character: A single character string formatted YYYY-MM-DD HH:MM:SS at which the nap should stop. The time zone is assumed to be device local. The hour, minute, and second do not need to be specified.
 
 ``` r
 naptime(as.character(lubridate::now() + lubridate::seconds(1)))
@@ -67,34 +87,40 @@ naptime(as.character(lubridate::now() + lubridate::seconds(1)))
 -   difftime: difference in time to nap
 
 ``` r
-naptime(difftime(lubridate::now() + seconds(1), lubridate::now()))
+naptime(difftime(lubridate::now() + lubridate::seconds(1), lubridate::now()))
 #> NULL
 ```
 
--   logical: nap for default duration
+-   logical: nap for default duration if TRUE, skip nap if FALSE
 
 ``` r
 naptime(TRUE)
-#> Warning: Logical passed to naptime(), sleeping for default duration
 #> NULL
 ```
 
--   generic: nap for default duration
+-   NULL; meaning no delay
 
 ``` r
-naptime(glm(rnorm(5) ~ rnorm(5)))
-#> Warning in model.matrix.default(mt, mf, contrasts): the response appeared
-#> on the right-hand side and was dropped
-#> Warning in model.matrix.default(mt, mf, contrasts): problem with term 1 in
-#> model.matrix: no columns are assigned
-#> Warning: unhandled input for naptime: Error in (function (classes, fdef, mtable) : unable to find an inherited method for function 'naptime' for signature '"glm"'
-#> ; sleeping for default duration
+naptime(NULL)
 #> NULL
 ```
 
-If you find a reasonable input-type for which `naptime::naptime()` doesn't have a reasonable response, please file [an issue](https://github.com/drknexus/naptime/issues).
+-   generic: By default this produces an error, however, you can set `naptime.permissive` as an option (or argument) that will cause this to nap for default duration instead.
 
-In addition, naptime will handle some specific errors: \* All negative intervals will be converted to a delay of 0 \* All non-finite intervals will be converted to a default delay \* All inputs that produce an error will be converted to a default delay
+``` r
+naptime(glm(rnorm(5) ~ runif(5)), permissive = TRUE)
+#> Warning: The time paramater was not scalar (length equal to 1)
+#> Warning: unhandled input for naptime(): Error in (function (classes, fdef, mtable) : unable to find an inherited method for function 'naptime' for signature '"list"'
+#> NULL
+options(naptime.permissive = TRUE)
+naptime(glm(rnorm(5) ~ runif(5)))
+#> Warning: The time paramater was not scalar (length equal to 1)
+
+#> Warning: unhandled input for naptime(): Error in (function (classes, fdef, mtable) : unable to find an inherited method for function 'naptime' for signature '"list"'
+#> NULL
+```
+
+If you find a reasonable input-type for which `naptime::naptime()` doesn't have a reasonable response, please file [an issue](https://github.com/drknexus/naptime/issues) or PR in which you resolve the shortcoming.
 
 How do I get it?
 ----------------

--- a/man/naptime.Rd
+++ b/man/naptime.Rd
@@ -12,24 +12,34 @@
 \alias{naptime,numeric-method}
 \title{Safe sleep function}
 \usage{
-naptime(time)
+naptime(time, permissive = getOption("naptime.permissive",
+  permissive_default))
 
-\S4method{naptime}{numeric}(time)
+\S4method{naptime}{numeric}(time, permissive = getOption("naptime.permissive",
+  permissive_default))
 
-\S4method{naptime}{Period}(time)
+\S4method{naptime}{Period}(time, permissive = getOption("naptime.permissive",
+  permissive_default))
 
-\S4method{naptime}{POSIXct}(time)
+\S4method{naptime}{POSIXct}(time, permissive = getOption("naptime.permissive",
+  permissive_default))
 
-\S4method{naptime}{difftime}(time)
+\S4method{naptime}{difftime}(time,
+  permissive = getOption("naptime.permissive", permissive_default))
 
-\S4method{naptime}{logical}(time)
+\S4method{naptime}{logical}(time, permissive = getOption("naptime.permissive",
+  permissive_default))
 
-\S4method{naptime}{`NULL`}(time)
+\S4method{naptime}{`NULL`}(time, permissive = getOption("naptime.permissive",
+  permissive_default))
 
-\S4method{naptime}{character}(time)
+\S4method{naptime}{character}(time,
+  permissive = getOption("naptime.permissive", permissive_default))
 }
 \arguments{
 \item{time}{Time to sleep, polymorphic type inputs, leaning towards units as 'seconds'}
+
+\item{permissive}{An optional argument to override the \code{naptime.permissive option} for this call of the naptime function}
 }
 \value{
 NULL; A side effect of a pause in program execution
@@ -38,14 +48,18 @@ NULL; A side effect of a pause in program execution
 Acceptable inputs:
 \itemize{
  \item numeric: time in seconds to nap
- \item NULL: nap for default duration
  \item POSIXct: time at which the nap should stop  (timezone is respected)
- \item Period: time from now at which the nap should stop
  \item character: yyyy-mm-dd hh:mm:ss at which nap should stop, time zone is assumed to be Sys.timezone() and hh:mm:ss is optional as three formats may be missing, cf. lubridate::ymd_hms().
+ \item Period: time from now at which the nap should stop
  \item difftime: difference in time to nap
- \item logical: nap for default duration
- \item generic: nap for default duration
+ \item logical: If TRUE, nap for default duration, otherwise don't nap.
+ \item NULL: don't nap
+ \item generic: error or nap for default duration depending on the option naptime.permissive
 }
+}
+\details{
+The default duration is set with a numeric for the option \code{naptime.default_delay} in seconds (default: 0.1)
+Whether a generic input is accepted is determined by the option \code{naptime.permissive} (default: FALSE)
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-naptime.R
+++ b/tests/testthat/test-naptime.R
@@ -55,6 +55,7 @@ test_that("test of NA dispatch", {
   expect_gte(na_test, 0)
   expect_lte(na_test, 3)
   expect_error(naptime(NA_character_))
+  expect_warning(naptime(NA_character_, permissive = TRUE))
 })
 
 test_that("test of logical dispatch", {
@@ -65,6 +66,7 @@ test_that("test of logical dispatch", {
   expect_gte(false_test, 0)
   expect_lte(false_test, 3)
   expect_error(naptime(logical(0)))
+  expect_warning(naptime(logical(0), permissive = TRUE))
 })
 
 test_that("test of no_arg dispatch", {
@@ -75,6 +77,10 @@ test_that("test of no_arg dispatch", {
 
 test_that("non-time character produces warning, not an error", {
   testval <- "boo"
+  expect_error(naptime(testval))
+  expect_warning(naptime(testval, permissive = TRUE))
+
+  testval <- "really long scary text string"
   expect_error(naptime(testval))
   expect_warning(naptime(testval, permissive = TRUE))
   non_time_test <- system.time(naptime(testval, permissive = TRUE))[["elapsed"]]
@@ -136,4 +142,10 @@ test_that("generic warning if permissive", {
   options(naptime.permissive = TRUE)
   expect_warning(naptime(glm(rnorm(5) ~ runif(5))))
   expect_error(naptime(glm(rnorm(5) ~ runif(5)), permissive = FALSE))
+})
+
+test_that("zero length custom class produces a warning", {
+  boo <- integer(0)
+  class(boo) <- "moo"
+  expect_warning(naptime(boo))
 })

--- a/tests/testthat/test-naptime.R
+++ b/tests/testthat/test-naptime.R
@@ -7,20 +7,20 @@ test_that("test of numeric dispatch", {
   test2 <- system.time(naptime(5L))[["elapsed"]]
   expect_gte(test2, 2)
   expect_lte(test2, 7)
-  expect_warning(naptime(Inf))
-  expect_warning(naptime(-10))
-  inf_test <- system.time(naptime(Inf))[["elapsed"]]
-  neg_test <- system.time(naptime(-10))[["elapsed"]]
+  inf_test <- system.time(expect_error(naptime(Inf)))[["elapsed"]]
+  inf_test <- system.time(expect_warning(naptime(Inf, permissive = TRUE)))[["elapsed"]]
+  neg_test <- system.time(expect_warning(naptime(-10)))[["elapsed"]]
   expect_gte(inf_test, 0)
   expect_lte(inf_test, 2)
   expect_gte(neg_test, 0)
   expect_lte(neg_test, 2)
+  expect_error(naptime(c(1,2)))
 })
 
 test_that("numeric dispatch warnings can be disabled", {
   # Disable warnings
   options(naptime.warnings = FALSE)
-  expect_silent(naptime(Inf))
+  expect_silent(naptime(Inf, permissive = TRUE))
   expect_silent(naptime(-10))
   options(naptime.warnings = TRUE)
 })
@@ -38,7 +38,7 @@ test_that("test of POSIXct dispatch", {
 })
 
 test_that("test of difftime error conditions", {
-  difftime_test <- system.time(naptime(difftime("2016-01-01 00:00:00", "2016-01-01 00:00:05")))[["elapsed"]]
+  difftime_test <- system.time(expect_warning(naptime(difftime("2016-01-01 00:00:00", "2016-01-01 00:00:05"))))[["elapsed"]]
   expect_gte(difftime_test, 0)
   expect_lte(difftime_test, 3)
 })
@@ -50,9 +50,11 @@ test_that("test of NULL dispatch", {
 })
 
 test_that("test of NA dispatch", {
-  na_test <- system.time(naptime(NA))[["elapsed"]]
+  expect_error(naptime(NA, permissive = FALSE))
+  na_test <- system.time(expect_warning(naptime(NA, permissive = TRUE)))[["elapsed"]]
   expect_gte(na_test, 0)
   expect_lte(na_test, 3)
+  expect_error(naptime(NA_character_))
 })
 
 test_that("test of logical dispatch", {
@@ -62,6 +64,7 @@ test_that("test of logical dispatch", {
   false_test <- system.time(naptime(FALSE))[["elapsed"]]
   expect_gte(false_test, 0)
   expect_lte(false_test, 3)
+  expect_error(naptime(logical(0)))
 })
 
 test_that("test of no_arg dispatch", {
@@ -72,8 +75,9 @@ test_that("test of no_arg dispatch", {
 
 test_that("non-time character produces warning, not an error", {
   testval <- "boo"
-  expect_warning(naptime(testval))
-  non_time_test <- system.time(naptime(testval))[["elapsed"]]
+  expect_error(naptime(testval))
+  expect_warning(naptime(testval, permissive = TRUE))
+  non_time_test <- system.time(naptime(testval, permissive = TRUE))[["elapsed"]]
   expect_gte(non_time_test, 0)
   expect_lte(non_time_test, 3)
 })
@@ -81,8 +85,9 @@ test_that("non-time character produces warning, not an error", {
 test_that("non-valid produces warning, not an error", {
   testval <- pi
   class(testval) <- "bad-class"
-  expect_warning(naptime(testval))
-  non_class_test <- system.time(naptime(testval))[["elapsed"]]
+  expect_error(naptime(testval))
+  expect_warning(naptime(testval, permissive = TRUE))
+  non_class_test <- system.time(naptime(testval, permissive = TRUE))[["elapsed"]]
   expect_gte(non_class_test, 0)
   expect_lte(non_class_test, 3)
 })
@@ -118,6 +123,17 @@ test_that("character date handling: yyyy-mm-dd hh:mm:ss in future", {
   expect_lte(pos_period_test, 7)
 })
 
-test_that("generic warning", {
-  expect_warning(naptime(glm(rnorm(5) ~ rnorm(5))))
+test_that("generic stop", {
+  expect_error(naptime(glm(rnorm(5) ~ rnorm(5))))
+})
+
+
+test_that("generic warning if permissive", {
+  options(naptime.permissive = FALSE)
+  expect_error(naptime(glm(rnorm(5) ~ runif(5))))
+  expect_warning(naptime(glm(rnorm(5) ~ runif(5)), permissive = TRUE))
+
+  options(naptime.permissive = TRUE)
+  expect_warning(naptime(glm(rnorm(5) ~ runif(5))))
+  expect_error(naptime(glm(rnorm(5) ~ runif(5)), permissive = FALSE))
 })

--- a/vignettes/naptime.R
+++ b/vignettes/naptime.R
@@ -1,0 +1,47 @@
+## ---- echo = FALSE, results='asis'---------------------------------------
+# Include badges only when making the github markdown
+library(knitr)
+if ("md_document" %in% rmarkdown::all_output_formats(knitr::current_input())) {
+  cat("
+[![License](http://img.shields.io/badge/license-GPL%20%28%3E=%202%29-brightgreen.svg?style=flat)](http://www.gnu.org/licenses/gpl-2.0.html)
+[![Travis-CI Build Status](https://travis-ci.org/drknexus/naptime.svg?branch=master)](https://travis-ci.org/drknexus/naptime)
+[![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/naptime)](https://cran.r-project.org/package=naptime)
+[![codecov.io](https://codecov.io/github/drknexus/naptime/coverage.svg?branch=master)](https://codecov.io/github/drknexus/naptime?branch=master)
+      ")
+}
+
+## ---- echo = FALSE, results = 'hide', message = FALSE--------------------
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.path = "README-"
+)
+library(naptime)
+library(lubridate)
+
+## ------------------------------------------------------------------------
+naptime(1)
+
+## ------------------------------------------------------------------------
+naptime(lubridate::now(tzone = "UTC")+lubridate::seconds(1))
+
+## ------------------------------------------------------------------------
+naptime(lubridate::seconds(1))
+
+## ------------------------------------------------------------------------
+naptime(as.character(lubridate::now() + lubridate::seconds(1)))
+
+## ------------------------------------------------------------------------
+naptime(difftime(lubridate::now() + lubridate::seconds(1), lubridate::now()))
+
+## ------------------------------------------------------------------------
+naptime(TRUE)
+
+## ------------------------------------------------------------------------
+naptime(NULL)
+
+## ------------------------------------------------------------------------
+naptime(glm(rnorm(5) ~ runif(5)), permissive = TRUE)
+options(naptime.permissive = TRUE)
+naptime(glm(rnorm(5) ~ runif(5)))
+

--- a/vignettes/naptime.Rmd
+++ b/vignettes/naptime.Rmd
@@ -71,11 +71,11 @@ repeat{
 
 ## How do I use it?
 
-Because `naptime()` has nearly identicial arguments and behavior as `base::Sys.sleep()` in response to numeric inputs,  it can be nearly used as a drop-in replacement for `base::Sys.sleep()`.  
+Because `naptime()` has nearly identical arguments and behavior as `base::Sys.sleep()` in response to numeric inputs,  it can be nearly used as a drop-in replacement for `base::Sys.sleep()`.  
 
 There are two notable differences in the behavior of Sys.sleep() and naptime():
 
-* For the input value of `Inf` `base::Sys.sleep()` will sleep indefiniately.  In contrast, `naptime::naptime()` will produce an error (or if `naptime.permissive = TRUE` is set pause the default duration).
+* For the input value of `Inf` `base::Sys.sleep()` will sleep indefinitely.  In contrast, `naptime::naptime()` will produce an error (or if `naptime.permissive = TRUE` is set pause the default duration).
 * For a negative input value `base::Sys.sleep()` will produce an error.  In contrast, `naptime::naptime()` will assume that the period of delay has already elapsed and move forward without further delay.
 
 ### Options

--- a/vignettes/naptime.Rmd
+++ b/vignettes/naptime.Rmd
@@ -1,5 +1,5 @@
 ---
-title: 'naptime: A Robust Flexible Sys.sleep() Replacement'
+title: 'naptime: A Flexible and Robust Sys.sleep() Replacement'
 author: "Russell S. Pierce & Timothy Gann"
 date: '`r Sys.Date()`'
 output:
@@ -37,22 +37,53 @@ library(lubridate)
 
 ## Why should I use it?
 
-The premise of naptime is two fold.  
+naptime makes delaying code execution in R more flexible and robust. It makes delaying code execution more flexible by supporting more data types than `base::Sys.sleep()`.  It makes delaying code more robust by allowing errors in the delay specification to throw warnings instead of errors.  Most notably, because naptime supports more input data types, you can use package:lubridate functions in conjunction with naptime to yield human readable time delays and intervals.
 
-1. Delays in R code should never result in an error.
-2. Functions should accept multiple inputs types, but result in a single output type or side-effect.  
+Consider the case of waiting one hour:
+```
+Sys.sleep(3600)
 
-In response to these considerations `naptime::naptime()` either sleeps for the specified duration, or passes forward with a warning.  It has the same argument name as `base::Sys.sleep()` and a nearly identical behavior in response to numeric inputs.  As such, it can be nearly used as a drop-in replacement for `base::Sys.sleep()`.  
+# versus
 
-The one notable exception to identical behavior is the input value of `Inf`. `base::Sys.sleep()` will sleep indefiniately in reponse to `Inf`.  In contrast, `naptime::naptime()` will sleep the default duration.
+naptime(lubridate::hours(1))
+```
+
+Consider the case of wanting to start processing every hour for a job of an indeterminate duration:
+
+```
+repeat{
+  start_time <- lubridate::now()
+  # Do processing
+  sleep_duration <- 3600 - as.numeric(lubridate::now() - start_time)
+  if (sleep_duration > 0) {
+    Sys.sleep(sleep_duration)
+  }
+}
+
+# versus
+
+repeat{
+  start_time <- lubridate::now()
+  # Do processing
+  naptime(start_time + hours(1))
+}
+```
 
 ## How do I use it?
+
+Because `naptime()` has nearly identicial arguments and behavior as `base::Sys.sleep()` in response to numeric inputs,  it can be nearly used as a drop-in replacement for `base::Sys.sleep()`.  
+
+There are two notable differences in the behavior of Sys.sleep() and naptime():
+
+* For the input value of `Inf` `base::Sys.sleep()` will sleep indefiniately.  In contrast, `naptime::naptime()` will produce an error (or if `naptime.permissive = TRUE` is set pause the default duration).
+* For a negative input value `base::Sys.sleep()` will produce an error.  In contrast, `naptime::naptime()` will assume that the period of delay has already elapsed and move forward without further delay.
 
 ### Options
 All options are set via `base::options()`.
 
 * `naptime.default_delay`.  If left unchanged, the default delay is `.1` seconds.
 * `naptime.warnings`.  If left unchanged, the default is `TRUE`, to show warnings.
+* `naptime.permissive`.  If left unchanged, the default is `FALSE`, to trigger errors on inputs that couldn't be converted into something sensible.  If set TRUE, inputs that couldn't be converted into something sensible will result in a default delay.
 
 ### Polymorphic inputs
 naptime() accepts a wide variety of inputs.
@@ -63,44 +94,48 @@ Polymorphism for:
 ```{r}
 naptime(1)
 ```
- * NULL
-```{r}
-naptime(NULL)
-```
+
  * POSIXct: time at which the nap should stop (timezone is respected)
 ```{r}
 naptime(lubridate::now(tzone = "UTC")+lubridate::seconds(1))
 ```
- * Period: time from now at which the nap should stop
+
+* Period: time from now at which the nap should stop
 ```{r}
 naptime(lubridate::seconds(1))
 ```
 
- * character: ymd_hms at which nap should stop, time zone is assumed to be device local.  The hour, minute, and second do not need to be specified.
+* character: A single character string formatted YYYY-MM-DD HH:MM:SS at which the nap should stop. The time zone is assumed to be device local.  The hour, minute, and second do not need to be specified.
 ```{r}
 naptime(as.character(lubridate::now() + lubridate::seconds(1)))
 ```
- 
- * difftime: difference in time to nap
+
+* difftime: difference in time to nap
 ```{r}
-naptime(difftime(lubridate::now() + seconds(1), lubridate::now()))
+naptime(difftime(lubridate::now() + lubridate::seconds(1), lubridate::now()))
 ```
 
- * logical: nap for default duration
+* logical: nap for default duration if TRUE, skip nap if FALSE
 ```{r}
 naptime(TRUE)
 ```
 
- * generic: nap for default duration
+ * NULL; meaning no delay
 ```{r}
-naptime(glm(rnorm(5) ~ rnorm(5)))
+naptime(NULL)
 ```
-If you find a reasonable input-type for which `naptime::naptime()` doesn't have a reasonable response, please file [an issue](https://github.com/drknexus/naptime/issues).
 
-In addition, naptime will handle some specific errors:
-* All negative intervals will be converted to a delay of 0
-* All non-finite intervals will be converted to a default delay
-* All inputs that produce an error will be converted to a default delay
+ * generic: By default this produces an error, however, you can set `naptime.permissive` as an option (or argument) that will cause this to nap for default duration instead.
+```{r}
+naptime(glm(rnorm(5) ~ runif(5)), permissive = TRUE)
+options(naptime.permissive = TRUE)
+naptime(glm(rnorm(5) ~ runif(5)))
+```
+
+If you find a reasonable input-type for which `naptime::naptime()` doesn't have a reasonable response, please file [an issue](https://github.com/drknexus/naptime/issues) or PR in which you resolve the shortcoming.
+
+
+
 
 ## How do I get it?
 

--- a/vignettes/naptime.Rmd
+++ b/vignettes/naptime.Rmd
@@ -7,17 +7,22 @@ output:
   md_document:
     variant: markdown_github
 vignette: >
-  %\VignetteIndexEntry{How and Why to Nap}
+  %\VignetteIndexEntry{Why and How to Nap}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
 
-```{r, echo = FALSE}
-# Uncomment for building github markdown
-# [![License](http://img.shields.io/badge/license-GPL%20%28%3E=%202%29-brightgreen.svg?style=flat)](http://www.gnu.org/licenses/gpl-2.0.html)
-# [![Travis-CI Build Status](https://travis-ci.org/drknexus/naptime.svg?branch=master)](https://travis-ci.org/drknexus/naptime)
-# [![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/naptime)](https://cran.r-project.org/package=naptime)
-# [![codecov.io](https://codecov.io/github/drknexus/naptime/coverage.svg?branch=master)](https://codecov.io/github/drknexus/naptime?branch=master)
+```{r, echo = FALSE, results='asis'}
+# Include badges only when making the github markdown
+library(knitr)
+if ("md_document" %in% rmarkdown::all_output_formats(knitr::current_input())) {
+  cat("
+[![License](http://img.shields.io/badge/license-GPL%20%28%3E=%202%29-brightgreen.svg?style=flat)](http://www.gnu.org/licenses/gpl-2.0.html)
+[![Travis-CI Build Status](https://travis-ci.org/drknexus/naptime.svg?branch=master)](https://travis-ci.org/drknexus/naptime)
+[![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/naptime)](https://cran.r-project.org/package=naptime)
+[![codecov.io](https://codecov.io/github/drknexus/naptime/coverage.svg?branch=master)](https://codecov.io/github/drknexus/naptime?branch=master)
+      ")
+}
 ```
 
 ```{r, echo = FALSE, results = 'hide', message = FALSE}
@@ -53,6 +58,7 @@ All options are set via `base::options()`.
 naptime() accepts a wide variety of inputs.
 
 Polymorphism for:
+
  * numeric: time in seconds to nap
 ```{r}
 naptime(1)

--- a/vignettes/naptime.Rmd
+++ b/vignettes/naptime.Rmd
@@ -15,7 +15,7 @@ vignette: >
 ```{r, echo = FALSE, results='asis'}
 # Include badges only when making the github markdown
 library(knitr)
-if ("md_document" %in% rmarkdown::all_output_formats(knitr::current_input())) {
+if ("github_markdown" %in% knitr::opts_knit$get("rmarkdown.pandoc.to")) {
   cat("
 [![License](http://img.shields.io/badge/license-GPL%20%28%3E=%202%29-brightgreen.svg?style=flat)](http://www.gnu.org/licenses/gpl-2.0.html)
 [![Travis-CI Build Status](https://travis-ci.org/drknexus/naptime.svg?branch=master)](https://travis-ci.org/drknexus/naptime)


### PR DESCRIPTION
Addresses https://github.com/drknexus/naptime/issues/6.  By default we are `naptime.permissive = FALSE` in which case we throw errors in nearly every case one would expect Sys.sleep with flexible dispatch to throw errors (with the addition of an error for `Inf` and the removal of an error for negative values).  With the option `naptime.permissive = TRUE` we obtain the original highly permissive behavior where real issues can be hidden as warnings rather than errors.  This option can be overridden for a single function call by the `permissive` parameter for naptime().  This allow naptime to operate on responses from external systems, say in response to an API's 429 response without needing to be certain that the response will be in a desirable format.